### PR TITLE
[PR] Allow users with publish_pages to use the Customizer

### DIFF
--- a/includes/wsuwp-extended-customizer-capabilities.php
+++ b/includes/wsuwp-extended-customizer-capabilities.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace WSUWP\Customizer_Capabilities;
+namespace WSU\Customizer_Capabilities;
 
-add_action( 'after_setup_theme', 'WSUWP\Customizer_Capabilities\bootstrap' );
-/**
- * Starts things up.
- *
- * @since 0.0.1
- */
-function bootstrap() {
+add_filter( 'map_meta_cap', 'WSU\Customizer_Capabilities\add_customizer_to_editors', 10, 3 );
+
+function add_customizer_to_editors( $caps, $cap, $user_id ) {
+	if ( 'customize' === $cap && user_can( $user_id, 'publish_pages' ) ) {
+		$caps = array( 'publish_pages' );
+	}
+
+	return $caps;
 }


### PR DESCRIPTION
This is a requirement in the WSU Insider theme, but the code must be added with a plugin rather than in the theme code due to how the Customizer loads the theme as a preview.